### PR TITLE
Use StringValuePtr rather than obsolete STR2CSTR for Ruby 1.9

### DIFF
--- a/ruby-ext/ext-helper.c
+++ b/ruby-ext/ext-helper.c
@@ -248,7 +248,7 @@ int cp_get1(VALUE obj, char *fmt, char *ivname, void *cval)
     cp_Check_Type(*fmt, 's', at_name);
     STRING_LENGTH = RSTRING_LEN(val);
     if (STRING_LENGTH > 0){
-      *(char**)cval = STR2CSTR(val);
+      *(char**)cval = StringValuePtr(val);
     } else {
       *(char**)cval = NULL;
     }


### PR DESCRIPTION
One more patch to compatible with Ruby 1.8/1.9.
