### PR TITLE
Explicitly declare EOL type for mhc-default-coding-system.

### DIFF
--- a/emacs/mhc-vars.el
+++ b/emacs/mhc-vars.el
@@ -82,7 +82,7 @@
   :type 'boolean)
 
 (defcustom mhc-default-coding-system
-  (if (>= emacs-major-version 20) 'utf-8 '*iso-2022-ss2-7*)
+  (if (>= emacs-major-version 20) 'utf-8-unix '*iso-2022-ss2-7*)
   "*Default coding system for MHC schedule files."
   :group 'mhc
   :type 'symbol)


### PR DESCRIPTION
For emacs23 and later on Windows, mhc-default-coding-system must have unix EOL type.

Cf. https://github.com/yoshinari-nomura/ancient-mhc/commit/45722789b39177d4326f3e066c44e9324fa07821
