### PR TITLE
Avoid incompatible encoding regexp match in protocol.rb (today)

### DIFF
--- a/today.in
+++ b/today.in
@@ -297,7 +297,7 @@ if mail_address
   if contents && contents != ''
     message = MhcKconv::tomail(header + contents)
     Net::SMTPSession .start(MailServer, 25, MyHostName) {|server|
-      server .sendmail(message, mail_address, [mail_address])
+      server .sendmail(message.force_encoding("BINARY"), mail_address, [mail_address])
     }
   end
 else


### PR DESCRIPTION
Feeding iso-2022-jp strings directly into net/smtp causes incompatible encoding regexp match.  
I'm not sure if this workaround is appropriate or not, though...
