### PR TITLE
Check RUBY_VERSION to use force_encoding

### DIFF
--- a/today.in
+++ b/today.in
@@ -296,8 +296,9 @@ if mail_address
 
   if contents && contents != ''
     message = MhcKconv::tomail(header + contents)
+    message .force_encoding("ASCII-8BIT") if RUBY_VERSION .to_f >= 1.9
     Net::SMTPSession .start(MailServer, 25, MyHostName) {|server|
-      server .sendmail(message.force_encoding("BINARY"), mail_address, [mail_address])
+      server .sendmail(message, mail_address, [mail_address])
     }
   end
 else


### PR DESCRIPTION
Please apply this patch to work with Ruby 1.8.
