### PR TITLE
Fix configure scripts to properly ignore absence of pilot-link library

### DIFF
--- a/configure.rb
+++ b/configure.rb
@@ -79,10 +79,10 @@ if conf['@@MHC_DISABLE_PALM@@'] == ''
   conf .search_library(lib_search_path,
                        'pisock',
                        'pi_socket',
-                       '@@MHC_PILOT_LINK_LIB@@', false, true)
+                       '@@MHC_PILOT_LINK_LIB@@', false, false)
   conf .search_include(inc_search_path,
                        'pi-dlp.h',
-                       '@@MHC_PILOT_LINK_INC@@', false, true)
+                       '@@MHC_PILOT_LINK_INC@@', false, false)
 end
 
 ################################################################

--- a/ruby-ext/extconf.rb.in
+++ b/ruby-ext/extconf.rb.in
@@ -1,7 +1,6 @@
 #!@@MHC_RUBY_PATH@@
 # -*- ruby -*-
 
-require 'mkmf'
 
 ################################################################
 # crate make file.
@@ -10,7 +9,9 @@ $CFLAGS  = "@@MHC_CFLAGS@@"
 $CFLAGS += " -DNEW_NAMING " if '@@MHC_RUBY_VERSION@@' >= '010300'
 $LDFLAGS = "@@MHC_LDFLAGS@@"
 
-if '@@MHC_DISABLE_PALM@@' == ''
+if '@@MHC_PILOT_LINK_LIB@@' != '' and '@@MHC_PILOT_LINK_INC@@' != ''
+  require 'mkmf'
+
 #  CONFIG["LDSHARED"] = "LD_RUN_PATH=@@MHC_PILOT_LINK_LIB@@ " +
 #    CONFIG["LDSHARED"]
 


### PR DESCRIPTION
Try to ignore absence of pilot-link library when 'ruby configure.rb' is called without  --disable-palm option.

Also, mkmf emits an error when no Makefile exists in the working directory upon exit, so don't require 'mkmf' when pilot-link is not installed or disabled and create_makefile is not called (You don't see the error when old Makefile exists).

By the way, even when I installed pilot-link (0.12.5), I couldn't build mhc_pilib.c on my FreeBSD machine.  Maybe palm support should be simply dropped?
