### PR TITLE
Do not assume that EOL is CRLF.

### DIFF
--- a/emacs/mhc-mime.el
+++ b/emacs/mhc-mime.el
@@ -142,7 +142,7 @@
 
 (defun mhc-mime-draft-reedit-file (file)
   (erase-buffer)
-  (insert-file-contents-as-raw-text-CRLF file)
+  (insert-file-contents-as-raw-text file)
   (mhc-mime/draft-reedit))
 
 


### PR DESCRIPTION
Currently, that code has no real harm in normal condition, because LF is also treated as EOL in *-dos coding system decoder.  But I feel using insert-file-contents-as-raw-text instead of insert-file-contents-as-raw-text-CRLF is more pertinent.
