### PR TITLE
Convert obsolete old-style backquotes.

### DIFF
--- a/emacs/mhc-face.el
+++ b/emacs/mhc-face.el
@@ -71,7 +71,7 @@ refer to mhc-calendar-hnf-face-alist-internal.")
     (mhc-calendar-hnf-face-uri  . (italic "blue" nil))))
 
 (defmacro mhc-face-put (symbol face)
-  (` (put-text-property 0 (length (, symbol)) 'face (, face) (, symbol))))
+  `(put-text-property 0 (length ,symbol) 'face ,face ,symbol))
 
 (eval-when-compile
   (cond
@@ -79,19 +79,19 @@ refer to mhc-calendar-hnf-face-alist-internal.")
     ;; XEmacs 21.2 (make-face-bold FACE &optional LOCALE TAGS)
     ;; XEmacs 21.1 (make-face-bold FACE &optional LOCALE)
     (defmacro mhc-face/make-face-bold (face)
-      (` (make-face-bold (, face))))
+      `(make-face-bold ,face))
     (defmacro mhc-face/make-face-italic (face)
-      (` (make-face-italic (, face))))
+      `(make-face-italic ,face))
     (defmacro mhc-face/make-face-bold-italic (face)
-      (` (make-face-bold-italic (, face)))))
+      `(make-face-bold-italic ,face)))
    (t
     ;; (make-face-bold FACE &optional FRAME NOERROR)
     (defmacro mhc-face/make-face-bold (face)
-      (` (make-face-bold (, face) nil t)))
+      `(make-face-bold ,face nil t))
     (defmacro mhc-face/make-face-italic (face)
-      (` (make-face-italic (, face) nil t)))
+      `(make-face-italic ,face nil t))
     (defmacro mhc-face/make-face-bold-italic (face)
-      (` (make-face-bold-italic (, face) nil t))))))
+      `(make-face-bold-italic ,face nil t)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; make faces from string/symbol

--- a/emacs/mhc-summary.el
+++ b/emacs/mhc-summary.el
@@ -842,7 +842,7 @@ If optional argument FOR-DRAFT is non-nil, Hilight message as draft message."
 ;;; Line format parsing
 
 (defmacro mhc-line-insert (string)
-  (` (and (stringp (, string)) (insert (, string)))))
+  `(and (stringp ,string) (insert ,string)))
 
 (defun mhc-line-parse-format (format spec-alist)
   (let ((f (mhc-string-to-char-list format))
@@ -885,15 +885,15 @@ If optional argument FOR-DRAFT is non-nil, Hilight message as draft message."
 
 
 (defmacro mhc-line-inserter-setup (inserter format alist)
-  (` (let (byte-compile-warnings)
-       (setq (, inserter)
-             (byte-compile
-              (list 'lambda ()
-                    (mhc-line-parse-format (, format) (, alist)))))
-       (when (get-buffer "*Compile-Log*")
-         (bury-buffer "*Compile-Log*"))
-       (when (get-buffer "*Compile-Log-Show*")
-             (bury-buffer "*Compile-Log-Show*")))))
+  `(let (byte-compile-warnings)
+     (setq ,inserter
+	   (byte-compile
+	    (list 'lambda ()
+		  (mhc-line-parse-format ,format ,alist))))
+     (when (get-buffer "*Compile-Log*")
+       (bury-buffer "*Compile-Log*"))
+     (when (get-buffer "*Compile-Log-Show*")
+       (bury-buffer "*Compile-Log-Show*"))))
 
 
 (defun mhc-summary-line-inserter-setup ()


### PR DESCRIPTION
Emacs24 byte compiler warns when old-style backquotes are detected.
It has been obsolete for more than a decade.
Could you please review if the conversion is correct?
