### PR TITLE
Replace obsolete 'string-to-int' to 'string-to-number'.

### DIFF
--- a/emacs/mhc-calendar.el
+++ b/emacs/mhc-calendar.el
@@ -954,7 +954,7 @@ The keys that are defined for mhc-calendar-mode are:
       (when (string= input "")
         (setq input (cdr (car alst))))
       (when (string-match "^\\([0-9]+\\)$" input)
-        (setq i (string-to-int input))
+        (setq i (string-to-number input))
         (when (> (length alst) i)
           (setq input (cdr (nth i alst)))))
       (when (string-match "^[0-9]+:[ \t]*" input)

--- a/emacs/mhc-cmail.el
+++ b/emacs/mhc-cmail.el
@@ -163,7 +163,7 @@
      ((looking-at mhc-cmail/summary-filename-regex)
       (buffer-substring (match-beginning 1) (match-end 1)))
      ((looking-at "^[ +]*\\([0-9]+\\)")
-      (string-to-int
+      (string-to-number
        (buffer-substring (match-beginning 1) (match-end 1))))
      (no-err
       nil)

--- a/emacs/mhc-date.el
+++ b/emacs/mhc-date.el
@@ -194,7 +194,7 @@
   (- yday -3 (% (- yday wday -382) 7)))
 
 (defmacro mhc-date/substring-to-int (str pos)
-  `(string-to-int
+  `(string-to-number
     (substring ,str (match-beginning ,pos) (match-end ,pos))))
 
 ;; according to our current time zone,

--- a/emacs/mhc-guess.el
+++ b/emacs/mhc-guess.el
@@ -606,7 +606,7 @@ You can specify following symbols as a list.
       (setq ret (concat ret (or (cdr (assoc chr z2h-alist)) chr)))
       (setq str (substring str (match-end 0))))
     (store-match-data data)
-    (string-to-int ret)))
+    (string-to-number ret)))
 
 
 ;;; Copyright Notice:

--- a/emacs/mhc-misc.el
+++ b/emacs/mhc-misc.el
@@ -44,10 +44,10 @@
 (defun mhc-misc-substring-to-int (str pos)
   (cond
    ((stringp str)
-    (string-to-int
+    (string-to-number
      (substring str (match-beginning pos) (match-end pos))))
    (t
-    (string-to-int
+    (string-to-number
      (buffer-substring (match-beginning pos) (match-end pos))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
The function 'string-to-int' is obsolete since 22.1, so I simply replaced it with 'string-to-number'
to reduce compile warnings. (I believe the function was introduced in Emacs 19.)

I'm not sure if some function names including "string-to-int" should be replaced too.
