### PR TITLE
Add tzinfo-data as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 gem "thor"
 gem "ri_cal", :git => 'https://github.com/yoshinari-nomura/ri_cal.git'
 gem "tzinfo"
+gem "tzinfo-data"


### PR DESCRIPTION
I need this to run mhc sync with MHC_TZINFO defined on my platform (FreeBSD 9).
