### PR TITLE
Fix lib/mhc/event.rb to handle comma-separeted X-SC-Day

### DIFF
--- a/lib/mhc/event.rb
+++ b/lib/mhc/event.rb
@@ -149,7 +149,7 @@ module Mhc
     end
 
     def dates=(string)
-      string = string.split.select {|s| /^!/ !~ s}.join(" ")
+      string = string.gsub(","," ").split.select {|s| /^!/ !~ s}.join(" ")
       return @dates = dates.parse(string)
     end
 


### PR DESCRIPTION
My mhc data which I convert by using update-uuid.sh includes comma (",") in X-SC-Day field.

So this pull request is to handle comma-separeted X-SC-Day.

I'm not sure whether I should hack mhc itself or update-uuid.sh, or should create an alternative script to replace comma of X-SC-Day in mhc data to space.
