### PR TITLE
Specify encoding of article file

### DIFF
--- a/emacs/mhc-summary.el
+++ b/emacs/mhc-summary.el
@@ -280,7 +280,8 @@ If optional argument FOR-DRAFT is non-nil, Hilight message as draft message."
       (let ((buffer-read-only nil))
         (goto-char (point-min))
         (erase-buffer)
-        (insert-file-contents file)
+	(mhc-insert-file-contents-as-coding-system
+	 mhc-default-coding-system file)
         (mhc-header-narrowing
           (mhc-header-delete-header
            "^\\(Content-.*\\|Mime-Version\\|User-Agent\\):" 'regexp))


### PR DESCRIPTION
In my environment, `mhc-summary-display-article` may fail to detect coding system of article file (`*.mhc`).