### PR TITLE
Specify coding system for MHC file.

### DIFF
--- a/emacs/mhc-calendar.el
+++ b/emacs/mhc-calendar.el
@@ -1530,7 +1530,8 @@ The keys that are defined for mhc-calendar-mode are:
                           mhc-calendar/hnf-ignore-categories))
               (setq lst (cdr lst))))
           (with-temp-buffer
-            (insert-file-contents mhcfile)
+            (insert-file-contents-as-coding-system
+	     mhc-default-coding-system mhcfile)
             (mhc-header-decode-ewords)
             (mhc-header-narrowing
               (setq cats (mhc-header-get-value "x-sc-category"))

--- a/emacs/mhc-calfw.el
+++ b/emacs/mhc-calfw.el
@@ -113,7 +113,8 @@
     (if schedule
         (cfw:details-popup
          (with-temp-buffer
-           (insert-file-contents
+           (insert-file-contents-as-coding-system
+	    mhc-default-coding-system
             (mhc-record-name (mhc-schedule-record schedule)))
            (mhc-calendar/view-file-decode-header)
            (buffer-string)

--- a/emacs/mhc-draft.el
+++ b/emacs/mhc-draft.el
@@ -101,7 +101,8 @@ If optional argument ORIGINAL is non-nil, BUFFER is raw buffer."
 (defsubst mhc-draft-reedit-file (filename)
   "Restore contents of file FILENAME as draft in the current buffer."
   (erase-buffer)
-  (insert-file-contents filename)
+  (mhc-insert-file-contents-as-coding-system
+   mhc-default-coding-system filename)
   (mhc-draft-reedit-buffer (current-buffer) 'original))
 
 

--- a/emacs/mhc.el
+++ b/emacs/mhc.el
@@ -871,7 +871,8 @@ the default action of this command is changed to the latter."
         (record (mhc-summary-record)))
     (if (and (stringp file) (file-exists-p file))
         (with-temp-buffer
-          (insert-file-contents file)
+	  (mhc-insert-file-contents-as-coding-system
+	   mhc-default-coding-system file)
           (mhc-header-decode-ewords)
           (mhc-draft-store-template
            (buffer-substring-no-properties (point-min) (point-max)))
@@ -894,7 +895,8 @@ the default action of this command is changed to the latter."
   (let ((filename (mhc-summary-filename))
         url)
     (with-temp-buffer
-      (insert-file-contents filename)
+      (mhc-insert-file-contents-as-coding-system
+       mhc-default-coding-system filename)
       (if (setq url (mhc-header-narrowing
                       (or (mhc-header-get-value "x-uri")
                           (mhc-header-get-value "x-url"))))


### PR DESCRIPTION
This is the same issue of  https://github.com/yoshinari-nomura/mhc/pull/30.  Auto detection for coding system of `.mhc` file may fail on Japanese Windows environment.  Moreover, I think it would be better there is a function such as `mhc-insert-mhc-file-contents`.
```lisp
(defun mhc-insert-mhc-file-contents (filename &optional visit beg end replace)
  (mhc-insert-file-contents-as-coding-system
   mhc-default-coding-system filename visit beg end replace))
```