### PR TITLE
Don't call MHC script directly on Windows.

### DIFF
--- a/emacs/mhc-process.el
+++ b/emacs/mhc-process.el
@@ -31,9 +31,7 @@
 			     ,mhc-ruby-program-name
 			     ,mhc-program-name
 			     "server"))))
-    (set-process-coding-system mhc-process
-			       mhc-default-coding-system
-			       mhc-default-coding-system)
+    (set-process-coding-system mhc-process 'utf-8 'utf-8)
     (set-process-query-on-exit-flag mhc-process nil)
     mhc-process))
 

--- a/emacs/mhc-process.el
+++ b/emacs/mhc-process.el
@@ -1,6 +1,6 @@
-(defvar mhc-process nil)
+(require 'mhc-vars)
 
-(add-to-list 'process-coding-system-alist '("^mhc$" . utf-8))
+(defvar mhc-process nil)
 
 (defun mhc-process-send-command (command)
   (unless (and (processp mhc-process)
@@ -24,11 +24,16 @@
     (if (and (processp mhc-process)
              (eq (process-status mhc-process) 'run))
         (kill-process mhc-process))
-    (setq mhc-process (start-process
-                       "mhc"
-                       (get-buffer-create " *mhc-scan-process*")
-                       "mhc"
-                       "server"))
+    (setq mhc-process
+	  (apply 'start-process
+		 (delq nil `("mhc"
+			     ,(get-buffer-create " *mhc-scan-process*")
+			     ,mhc-ruby-program-name
+			     ,mhc-program-name
+			     "server"))))
+    (set-process-coding-system mhc-process
+			       mhc-default-coding-system
+			       mhc-default-coding-system)
     (set-process-query-on-exit-flag mhc-process nil)
     mhc-process))
 

--- a/emacs/mhc-vars.el
+++ b/emacs/mhc-vars.el
@@ -13,7 +13,8 @@
 
 ;;; Code:
 (require 'mhc-compat)
-(require 'mhc-process)
+
+(autoload 'mhc-process-send-command "mhc-process")
 
 
 ;;; Constants:
@@ -24,6 +25,18 @@
 (defgroup mhc nil
   "Various sorts of MH Calender."
   :group 'mail)
+
+(defcustom mhc-program-name "mhc"
+  "Program name of MHC."
+  :group 'mhc
+  :type 'string)
+
+(defcustom mhc-ruby-program-name (when (eq system-type 'windows-nt) "ruby")
+  "When non-nil, specify ruby program name.
+Nil means MHC script is called directly."
+  :group 'mhc
+  :type '(choice (const :tag "Call script directly" nil)
+		 string))
 
 (defcustom mhc-start-day-of-week 0
   "*Day of the week as the start of the week."


### PR DESCRIPTION
On MS-Windows, Emacs can't call a script directly.  Furthermore, when mhc script called via ruby interpreter (as this change), setting of `process-coding-system-alist` has no effect.