### PR TITLE
Avoid referencing void variable

### DIFF
--- a/emacs/mhc-db.el
+++ b/emacs/mhc-db.el
@@ -30,7 +30,7 @@
            (if category  (format " --category=%s" category) "")
            (if search  (format " --search='%s'" search) ""))))
 
-(defun mhc-db-scan-flat (begin-date end-date &optional nosort category search)
+(defun mhc-db-scan-flat (b e &optional nosort category search)
   "Scan MHC database from BEGIN-DATE to END-DATE.
 Unlike `mhc-db-scan`, returned value is not grouped by date.
 For example:


### PR DESCRIPTION
I cannot use mhc-db-scan-flat because two value named b and e are not passed.
So, I renamed begin-date and end-date to b and e.