### PR TITLE
Make long single event create from region in mhc-summary

### DIFF
--- a/emacs/mhc-minibuf.el
+++ b/emacs/mhc-minibuf.el
@@ -254,12 +254,17 @@
                  (mhc-date-format default
                                   "%04d/%02d/%02d" yy mm dd))
                 ((listp default)
-                 (mapconcat
-                  (lambda (date)
-                    (mhc-date-format date
-                                     "%04d/%02d/%02d" yy mm dd))
-                  default
-                  " "))
+                 (let ((sep " ") (datelist default))
+                   (if (null (cdr (last default)))
+                       ()
+                     (setq sep "-")
+                     (setq datelist (list (car default) (cdr default))))
+                   (mapconcat
+                    (lambda (date)
+                      (mhc-date-format date
+                                       "%04d/%02d/%02d" yy mm dd))
+                    datelist
+                    sep)))
                 (t
                  nil)))
              (current-buffer)

--- a/emacs/mhc.el
+++ b/emacs/mhc.el
@@ -614,7 +614,7 @@ Returns t if the importation was succeeded."
        (list (get-buffer (read-buffer "Import buffer: "
                                       (current-buffer))))))
   (let ((draft-buffer (generate-new-buffer mhc-draft-buffer-name))
-        (current-date (or (mhc-summary-current-date) (mhc-calendar-get-date) (mhc-date-now)))
+        (current-date (or (mhc-summary-region-date) (mhc-summary-current-date) (mhc-calendar-get-date) (mhc-date-now)))
         (succeed t)
         msgp date time subject location category recurrence-tag priority alarm)
     (and (called-interactively-p 'interactive)


### PR DESCRIPTION
I implemented new feature what can make long single event create from selected region in mhc-summary.  In mhc-summary-mode, mark region and call `mhc-edit` (binding `E`), then date range (such as 2017/10/16-2017/10/17) is filled in minibuffer.

I'm beginner for elisp  and this is first PR.
Please advice me!