### PR TITLE
Close file handle just after read file for validation.

### DIFF
--- a/bin/mhc
+++ b/bin/mhc
@@ -274,7 +274,7 @@ class MhcCLI < Thor
       return 1
     end
 
-    errors = Mhc::Event.validate(File.open(full_path).read)
+    errors = Mhc::Event.validate(File.open(full_path) {|f| f.read})
 
     string = ""
     exit_on_error do


### PR DESCRIPTION
In my environment, `mhc-process-send-command-with-buffer` function fails to delete temporary file.  The cause is that ruby process keeps open file handle (probably until garbage collection).