### PR TITLE
mhc todo: Include how many days to the deadline

### DIFF
--- a/bin/mhc
+++ b/bin/mhc
@@ -132,7 +132,20 @@ class MhcCLI < Thor
       next if task.in_category?("done") && !options[:show_all]
       occurrence = task.occurrences(range: search_range).first
       deadline = occurrence.dtstart
-      puts format("%s %s", deadline.strftime("%Y/%m/%d %a"), task.subject)
+      deadline_string = ""
+      remaining = (deadline - Mhc::PropertyValue::Date.today).to_i
+      if remaining == 0
+        deadline_string = " (due this date)"
+      elsif remaining > 0
+        deadline_string = format(" (%d days to go)", remaining)
+      else
+        deadline_string = format(" (%d days overdue)", -remaining)
+      end
+      location_string = " [#{task.location}]" if !task.location.empty?
+      puts format("%s %-11s %s%s%s",
+                  deadline.strftime("%Y/%m/%d %a"),
+                  occurrence.time_range.to_mhc_string,
+                  task.subject, location_string, deadline_string)
     end
   end # todo
 


### PR DESCRIPTION
Also format the output more similar to the text formatter (including time_range and location).
```
% mhc todo
2019/08/07 Wed 14:00-15:00 today's task [somewhere] (due this date)
2019/08/10 Sat             saturday's task (3 days to go)
2019/08/06 Tue             overdue [nowhere] (1 days overdue)
```

Actually I wanted to utilize `Mhc::Formatter::Text`, but I couldn't initialize an instance without specifying `date_range`.
