### PR TITLE
Prevent warning of unused lexical argument

### DIFF
--- a/emacs/mhc.el
+++ b/emacs/mhc.el
@@ -325,10 +325,11 @@
         ret))))
 
 (defun mhc-expr-compile (string)
-  (byte-compile
-   `(lambda (schedule)
-      ,(mhc-expr-parse string)
-      )))
+  (let ((lexical-binding nil))
+    (byte-compile
+     `(lambda (schedule)
+	,(mhc-expr-parse string)
+	))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;


### PR DESCRIPTION
In Emacs 27.1, invoking mhc from the `*scratch*` buffer causes
"Warning: Unused lexical argument ‘schedule’".

It seems evaluating mhc-expr-compile() causes byte-compilation
with lexical binding unintentionally.

This patch prevents this warning with disabling lexical-binding.
