### PR TITLE
Update thor

### DIFF
--- a/mhc.gemspec
+++ b/mhc.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "thor",        ">= 0.19.1"
+  spec.add_runtime_dependency "thor",        ">= 1.2.0"
   spec.add_runtime_dependency "ri_cal",      ">= 0.8.8"
   spec.add_runtime_dependency "tzinfo",      ">= 1.2.2"
   spec.add_runtime_dependency "tzinfo-data", ">= 1.2015.4"


### PR DESCRIPTION
Bump up required thor's version to support latest did_you_mean.

We need https://github.com/rails/thor/commit/98dbec75e4237fb8fb1b4190fd91cc22ad65068f to suppress warning.