### PR TITLE
Fix duration of Emperor Shōwa's Birthday

### DIFF
--- a/samples/japanese-holidays.mhcc
+++ b/samples/japanese-holidays.mhcc
@@ -31,7 +31,7 @@ X-SC-Record-Id: AC1B378C-BAFE-4B6E-AF9C-78C2377E8AA4
 X-SC-Subject: 天皇誕生日
 X-SC-Category: Holiday Japanese
 X-SC-Cond: 29 Apr
-X-SC-Duration: 19480429-19980429
+X-SC-Duration: 19490429-19880429
 X-SC-Record-Id: B78EAAEE-9963-4573-9EC7-0879F8940AEE
 
 X-SC-Subject: みどりの日


### PR DESCRIPTION
The law was eforced at 1948/07/20, so the duration begins from 1949/04/29. 
And the end of the duration simply seems mistyped.

Cf. https://www.digital.archives.go.jp/img/130738