### PR TITLE
Add autoload cookie for mhc-import

### DIFF
--- a/README.org
+++ b/README.org
@@ -326,6 +326,7 @@
         (setq load-path
               (cons "~/src/mhc/emacs" load-path))
         (autoload 'mhc "mhc" "Message Harmonized Calendar system." t)
+        (autoload 'mhc-import "mhc" "Import a schedule." t)
 
         ;; M-x mhc
       #+END_SRC

--- a/emacs/mhc.el
+++ b/emacs/mhc.el
@@ -19,7 +19,8 @@
 ;;
 ;;  (setq load-path
 ;;        (cons "~/src/mhc/emacs" load-path))
-;;  (autoload 'mhc "mhc")
+;;  (autoload 'mhc "mhc" nil t)
+;;  (autoload 'mhc-import "mhc" nil t)
 ;;
 ;; and M-x mhc
 
@@ -797,6 +798,7 @@ Returns t if the importation was succeeded."
   :group 'mhc
   :type 'boolean)
 
+;;;###autoload
 (defun mhc-import (&optional get-original)
   "Import a schedule from the current article.
 The default action of this command is to import a schedule from the


### PR DESCRIPTION
`mhc-import` can be called via autolod feature.

```elisp
(autoload 'mhc-import "mhc" nil t)
```

I'm using `mhc-import` before staring MHC with no problem.  Please explicity support.
