### PR TITLE
warning-fix on ruby 3.3.0

### DIFF
--- a/mhc.gemspec
+++ b/mhc.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ri_cal",      ">= 0.8.8"
   spec.add_runtime_dependency "tzinfo",      ">= 1.2.2"
   spec.add_runtime_dependency "tzinfo-data", ">= 1.2015.4"
+  spec.add_runtime_dependency "nkf"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
`/.../lib/mhc.rb:3: warning: kconv is found in nkf, which will no longer be part of the default gems since Ruby 3.4.0. Add nkf to your Gemfile or gemspec.`