### PR TITLE
Add pstore as dependency in gemspec

### DIFF
--- a/mhc.gemspec
+++ b/mhc.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "pstore"
   spec.add_runtime_dependency "thor",        ">= 1.2.0"
   spec.add_runtime_dependency "rexml",       ">= 3.2.4"
   spec.add_runtime_dependency "ri_cal",      ">= 0.8.8"


### PR DESCRIPTION
Ruby 3.4 outputs below warning.

/.../lib/mhc/datastore.rb:122: warning: pstore was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0. You can add pstore to your Gemfile or gemspec to silence this warning.