### PR TITLE
Stricter hyphen checking of time formats.

### DIFF
--- a/lib/mhc/occurrence.rb
+++ b/lib/mhc/occurrence.rb
@@ -60,7 +60,8 @@ module Mhc
         if @start_date.respond_to?(:hour)
           @start_date
         else
-          @event.time_range.first.to_datetime(@start_date)
+          # if range is open, use end time as start time
+          @event.time_range.first&.to_datetime(@start_date) || dtend
         end
       end
     end
@@ -72,7 +73,8 @@ module Mhc
         if @end_date.respond_to?(:hour)
           @end_date
         else
-          @event.time_range.last.to_datetime(@end_date)
+          # if range is open, use start time as end time
+          @event.time_range.last&.to_datetime(@end_date) || dtstart
         end
       end
     end


### PR DESCRIPTION
## 概要

 * 以下のIssueへの修正プルリクエストになります。
   * #74

## 修正内容

 * 時間表記( `HH:MM` )のパースを行う際に、表記の前後にハイフンが含まれていた場合は `ParseError` 例外を投げる処理を追加しました。
 * また、修正を加えた `Mhc::PropertyValue::Range` クラスは時間表記だけでなく、何らかの「範囲」を含むデータを扱う汎用的なクラスであるように見えたため、 `@item_class` が `Mhc::PropertyValue::Time` であった場合のみチェックを行うようにしています。

## 修正内容において把握しきれていない箇所

 * `Mhc::PropertyValue::Range.parse()` メソッドには以下のコメントが添えられています。

```ruby
 14       # our Range acceps these 3 forms:
 15       #   (1) A-B    : first, last = A, B
 16       #   (2) A      : first, last = A, A
 17       #   (3) A-     : first, last = A, nil
 18       #   (4) -B     : first, last = nil, B
 19       #
 20       # nil means range is open (infinite).
 21       #
 22       def parse(string)
```

 * このコメントの `(3)` と `(4)` が今回チェックを追加した表記のように思えます。
 * そのため、 `mhc` の仕様上、以下のどちらの解釈になるかが私の方では把握しきれていません。
   * (ア). `A-` や `-B` はあくまでもパースされるパターン( `first` `last` の値がどうなるか)を示すだけのコメントであり、前後にハイフンを含む表記は想定していない。
     * この場合は今回のプルリクエストの内容で仕様通りの挙動になるかと思います。
   * (イ). `A-` `-B` といった表記も `mhc` 的には受け入れる仕様である。
     * この場合は今回のプルリクエストの修正内容は不適切になる。
     * ただその場合、現状の `HH:MM-` `-HH:MM` 指定で挙動がおかしくなる点につじつまが合わなくなる。

そのため、お手数をおかけしますが、コードレビューを行ってくださる際は、この部分の仕様についてもアドバイスをいただけるとありがたいです。
