### PR TITLE
native compile 対応

### DIFF
--- a/emacs/mhc-calendar.el
+++ b/emacs/mhc-calendar.el
@@ -18,6 +18,7 @@
 (require 'mhc-vars)
 (require 'mhc-face)
 (require 'mhc-e21)
+(require 'mhc-header)
 
 (defcustom mhc-calendar-language 'english
   "*Language of the calendar."

--- a/emacs/mhc-date.el
+++ b/emacs/mhc-date.el
@@ -38,6 +38,10 @@
 (defmacro mhc-time-MM (time)
   `(% ,time 60))
 
+(defmacro mhc-date/substring-to-int (str pos)
+  `(string-to-number
+    (substring ,str (match-beginning ,pos) (match-end ,pos))))
+
 ;; All constructors emit error signal if args are illegal.
 ;; In case called with noerror is t, return nil quietly.
 
@@ -199,10 +203,6 @@
 
 (defsubst mhc-date/iso-week-days (yday wday)
   (- yday -3 (% (- yday wday -382) 7)))
-
-(defmacro mhc-date/substring-to-int (str pos)
-  `(string-to-number
-    (substring ,str (match-beginning ,pos) (match-end ,pos))))
 
 ;; according to our current time zone,
 ;; convert timezone string into offset minutes

--- a/emacs/mhc-day.el
+++ b/emacs/mhc-day.el
@@ -30,6 +30,8 @@
 
 ;;; Code:
 
+(require 'mhc-date)
+
 ;; Function and macros to manipulate MHC-DAY structure:
 
 (defun mhc-day-new (date &optional year month day-of-month day-of-week holiday schedules)

--- a/emacs/mhc-db.el
+++ b/emacs/mhc-db.el
@@ -17,6 +17,8 @@
 (require 'mhc-day)
 (require 'mhc-process)
 (require 'mhc-schedule)
+(require 'mhc-record)
+(require 'mhc-date)
 
 (defun mhc-db-scan (begin-date end-date &optional nosort category search)
   "Scan MHC database from BEGIN-DATE to END-DATE.

--- a/emacs/mhc-draft.el
+++ b/emacs/mhc-draft.el
@@ -11,7 +11,8 @@
 
 ;;; Code:
 
-(require 'mhc-summary)
+(require 'mhc-calendar)
+(require 'mhc-header)
 
 ;; Global Variable:
 

--- a/emacs/mhc-logic.el
+++ b/emacs/mhc-logic.el
@@ -38,7 +38,10 @@
 
 ;;; Definition:
 (require 'mhc-date)
+(require 'mhc-compat)
 (require 'bytecomp)
+(require 'mhc-day)
+(require 'mhc-record)
 
 ;;----------------------------------------------------------------------
 ;;              MHC-LOGIC 構造体

--- a/emacs/mhc-message.el
+++ b/emacs/mhc-message.el
@@ -19,6 +19,8 @@
 
 ;;; Code:
 
+(require 'mhc-face)
+
 (defcustom mhc-message-mode-hook nil
   "*Hook run in mhc message mode buffers."
   :group 'mhc

--- a/emacs/mhc-minibuf.el
+++ b/emacs/mhc-minibuf.el
@@ -13,6 +13,11 @@
 ;;; Code:
 ;;;
 
+(require 'mhc-calendar)
+(require 'mhc-guess)
+(require 'mhc-misc)
+(require 'mhc-date)
+
 (defvar mhc-minibuf-candidate-to-s-func nil)
 (defvar mhc-minibuf-candidate-alist     nil)
 (defvar mhc-minibuf-candidate-offset    0)

--- a/emacs/mhc-parse.el
+++ b/emacs/mhc-parse.el
@@ -18,6 +18,7 @@
 (require 'mhc-record)
 (require 'mhc-header)
 (require 'mhc-misc)
+(require 'mhc-schedule)
 
 (defvar mhc-parse/strict nil)
 

--- a/emacs/mhc-record.el
+++ b/emacs/mhc-record.el
@@ -27,10 +27,7 @@
 
 ;;; Code:
 
-(require 'mhc-summary)
 (require 'mhc-file)
-(require 'mhc-draft)
-(require 'mhc-logic)
 
 (eval-when-compile
   (mhc-file-setup))

--- a/emacs/mhc-schedule.el
+++ b/emacs/mhc-schedule.el
@@ -35,6 +35,11 @@
 
 
 ;;; Codes:
+
+(require 'mhc-logic)
+(require 'mhc-compat)
+(require 'mhc-record)
+
 (defun mhc-schedule-new
   (record &optional condition subject location time alarm categories priority region recurrence-tag sequence)
   "Constructor of MHC-SCHEDULE structure."

--- a/emacs/mhc-summary.el
+++ b/emacs/mhc-summary.el
@@ -31,11 +31,14 @@
 
 ;;; Code:
 
+(require 'mhc-face)
 (require 'mhc-vars)
 (require 'mhc-day)
 (require 'mhc-compat)
 (require 'mhc-schedule)
 (require 'bytecomp)
+(require 'mhc-record)
+(require 'mhc-header)
 
 ;;; Global Variables:
 

--- a/emacs/mhc.el
+++ b/emacs/mhc.el
@@ -48,6 +48,8 @@
 (require 'mhc-face)
 (require 'mhc-calendar)
 (require 'mhc-draft)
+(require 'mhc-header)
+(require 'mhc-compat)
 
 (cond
  ((eval-when-compile  (and (not (featurep 'xemacs))


### PR DESCRIPTION
Emacs 30 からデフォルトで native compile が有効になったのですが、MHC は現状 native compile による JIT コンパイルが有効だと動作しないので、それを修正しようとするものです。

具体的には、コンパイル時に定義されていないマクロ呼び出しがあると関数呼び出しとしてコンパイルされ、実行時に Invalid function となって動作しないようです。MHC のビルド時には make で mhc をロードしてコンパイルしていますが、バックグラウンドの JIT コンパイラは別プロセスの Emacs で実行され mhc の事前ロードなどないため、各 el ファイルで適切に require 等する必要があるようです。
参考 (Mew の件) https://debbugs.gnu.org/cgi/bugreport.cgi?bug=50285

それで、各 el の macro の使用状況を見て require を足していったのですが、単純に足すだけだと依存関係が循環してしまいバイトコンパイルできなかったので、場当たり的に require を足し引きして調整しています。また、mhc-date.el でマクロの定義が呼び出しより後になっている所があり移動しました。とりあえずこれで手元で普段生活する範囲では動作している、という状況です。もっと適切なやり方があればコメントいただければと思います。

mhc-sync.el の mhc-calendar-p だけ循環が解決できておらず多分動かないのですが、現状 mhc-sync 自体も同梱されておらず自分でも使っていないので、そのままになっています。また、mhc-calfw.el が lexical-let を使っていて cl をロードしていないので動かないようです。他にも見落し等あるかもしれません。
